### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,35 @@
+{
+  "name": "mediawiki/favorites",
+  "type": "mediawiki-extension",
+  "description": "The Favorites extension makes it easy for users to add pages to their personal favorites list with just one click, so they can browse through them again later or share their favorites with others.",
+  "homepage": "https://www.mediawiki.org/wiki/Extension:Favorites",
+  "license": "GPL-2.0-or-later",
+  "require": {
+    "composer/installers": ">=1.0.1"
+  },
+  "config": {
+    "prepend-autoloader": false,
+    "optimize-autoloader": true
+  },
+  "require-dev": {
+    "jakub-onderka/php-parallel-lint": "1.0.0",
+    "jakub-onderka/php-console-highlighter": "0.3.2",
+    "mediawiki/mediawiki-codesniffer": "28.0.0",
+    "mediawiki/minus-x": "0.3.1",
+    "mediawiki/mediawiki-phan-config": "0.6.1"
+  },
+  "scripts": {
+    "fix": [
+      "phpcbf",
+      "minus-x fix ."
+    ],
+    "test": [
+      "parallel-lint . --exclude vendor --exclude node_modules",
+      "phpcs -p -s",
+      "minus-x check ."
+    ]
+  },
+  "extra": {
+    "phan-taint-check-plugin": "2.0.1"
+  }
+}


### PR DESCRIPTION
In order to use Composer for the installation of MediaWiki and the extensions I need I like to add a `composer.json` file.