### PR TITLE
Fixes for compatibility with version 1.39

### DIFF
--- a/includes/FavoritelistEditor.php
+++ b/includes/FavoritelistEditor.php
@@ -476,7 +476,7 @@ class FavoritelistEditor {
 	 * @return int
 	 */
 	public static function getMode( $request, $par ) {
-		$mode = strtolower( $request->getVal( 'action', $par ) );
+		$mode = strtolower( $request->getVal( 'action', $par ) ?? '' );
 		switch ( $mode ) {
 			case 'clear':
 				return self::EDIT_CLEAR;

--- a/includes/specials/SpecialFavoritelist.php
+++ b/includes/specials/SpecialFavoritelist.php
@@ -264,24 +264,24 @@ class ViewFavorites {
 		$dbr = wfGetDB( DB_PRIMARY );
 		$uid = intval( $user->getId() );
 		list( $favoritelist, $page ) = $dbr->tableNamesN( 'favoritelist', 'page' );
-		$sql = "SELECT fl_namespace, fl_title, page_id, page_len, page_is_redirect
+		$sql = "SELECT fl_namespace as page_namespace, fl_title as page_title, page_id, page_len, page_is_redirect, page_is_new, page_latest, page_touched, page_content_model
 			FROM {$favoritelist} LEFT JOIN {$page} ON ( fl_namespace = page_namespace
 			AND fl_title = page_title ) WHERE fl_user = {$uid}";
 		$res = $dbr->query( $sql, __METHOD__ );
 		if ( $res->numRows() > 0 ) {
 			$cache = MediaWikiServices::getInstance()->getLinkCache();
 			foreach ( $res as $row ) {
-				$title = Title::makeTitleSafe( $row->fl_namespace, $row->fl_title );
+				$title = Title::makeTitleSafe( $row->page_namespace, $row->page_title );
 				if ( $title instanceof Title ) {
 					// Update the link cache while we're at it
 					if ( $row->page_id ) {
-						$cache->addGoodLinkObj( $row->page_id, $title, $row->page_len, $row->page_is_redirect );
+						$cache->addGoodLinkObjFromRow( $title, $row );
 					} else {
 						$cache->addBadLinkObj( $title );
 					}
 					// Ignore non-talk
 					if ( !$title->isTalkPage() ) {
-						$titles[$row->fl_namespace][$row->fl_title] = $row->page_is_redirect;
+						$titles[$row->page_namespace][$row->page_title] = $row->page_is_redirect;
 					}
 				}
 			}


### PR DESCRIPTION
Class: SpecialFavoritelist.php
Method: getFavoritelistInfo( $user )
Fix: replaced addGoodLinkObj with addGoodLinkObjFromRow

Class: FavoritelistEditor.php
Method: getMode( $request, $par )
Fix: added the null coalescing operator (?? '') to strtolower (to provide a default value)